### PR TITLE
android java package rename: com.github.realxtend -> org.realxtend.tundra

### DIFF
--- a/src/Android/AndroidManifest.xml
+++ b/src/Android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.github.realxtend"
+    package="org.realxtend.tundra"
     android:versionCode="1"
     android:versionName="1.0">
     <uses-permission android:name="android.permission.INTERNET" />

--- a/src/Android/src/org/realxtend/tundra/Tundra.java
+++ b/src/Android/src/org/realxtend/tundra/Tundra.java
@@ -1,6 +1,6 @@
 // For conditions of distribution and use, see copyright notice in LICENSE
 
-package com.github.realxtend;
+package org.realxtend.tundra;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/TundraCore/TundraVersionInfo.h
+++ b/src/TundraCore/TundraVersionInfo.h
@@ -60,5 +60,5 @@
 /** @def TUNDRA_PACKAGE_NAME
     Android package name that is important for correctly loading Tundra plugins. Ignored on desktop platforms */
 #ifndef TUNDRA_PACKAGE_NAME
-#define TUNDRA_PACKAGE_NAME "com.github.realxtend"
+#define TUNDRA_PACKAGE_NAME "org.realxtend.tundra"
 #endif


### PR DESCRIPTION
just happened to see this while reading, haven't tested building for android (yet).
figured that github and google (if we submit to Play) don't like it if we pose as made by github..

googled this a bit and apparently other github projects have it like this too so i guess it's fine. anyhow as we have our own domain too i think this is more correct.

did a search to find all occurrences and tried to move the dir accordingly.
but can't be 100% that's correct as couldn't build for android yet.
