### PR TITLE
Solve this problem ...

### DIFF
--- a/tools/Linux/Ubuntu/Build.bash
+++ b/tools/Linux/Ubuntu/Build.bash
@@ -55,7 +55,7 @@ build_tests="OFF"
 # Parse command line args
 
 while [[ $1 = -* ]]; do
-    arg=$1; 
+    arg=$1;
     shift
 
     case $arg in
@@ -111,7 +111,7 @@ if [ $skip_pkg = false ] ; then
     sudo apt-get -y --quiet install \
         build-essential gcc \
         cmake \
-        autoconf libtool
+        autoconf libtool libtool-bin
 
     print_subtitle "Source control"
     sudo apt-get -y --quiet install \
@@ -203,7 +203,7 @@ if [ $skip_deps = false ] ; then
             -DURHO3D_URHO2D=0
 
         make -j $num_cpu -S
-        
+
         cp -L lib/libUrho3D.so $TUNDRA_BIN/
 
         mark_built
@@ -341,7 +341,7 @@ if [ $skip_deps = false ] ; then
         make install
 
         mark_built
-    fi    
+    fi
 
     #### boost
 


### PR DESCRIPTION
installing libtool-bin:
...
buildconf: autoconf version 2.69 (ok)
buildconf: autom4te version 2.69 (ok)
buildconf: autoheader version 2.69 (ok)
buildconf: automake version 1.15 (ok)
buildconf: aclocal version 1.15 (ok)
buildconf: libtool not found.
            You need GNU libtool 1.4.2 or newer installed.
...